### PR TITLE
added string literal parsing

### DIFF
--- a/src/base_definitions/tokens.hpp
+++ b/src/base_definitions/tokens.hpp
@@ -57,8 +57,17 @@ struct Token {
                 return purple_blue(std::get<std::string>(literal.value()));
             case TokenType::builtin_type: 
                 return id_gold(std::get<std::string>(literal.value()));
-            case TokenType::string:
-                return enum_green(std::get<std::string>(literal.value()));
+            case TokenType::string: {
+                std::string raw{std::get<std::string>(literal.value())};
+                std::string escaped{};
+                escaped.reserve(raw.length());
+                for (char &c : raw) {
+                    escaped += (c == '\n') ? "\\n" :
+                               (c == '\t') ? "\\t" :
+                               std::string(1, c);
+                }
+                return enum_green(escaped);
+            }
             case TokenType::is_EOF:
                 return "EOF";
             default: 

--- a/src/lexer/lexer.cpp
+++ b/src/lexer/lexer.cpp
@@ -34,7 +34,10 @@
             tokens.push_back(parse_identifier());
             continue;
         }
-        // TODO: - add string literal parsing
+        if (curr == '"') {
+            tokens.push_back(parse_string_literal());
+            continue;
+        }
         switch (curr) {
             //
             // -----------------------------------------------------------

--- a/src/lexer/lexer.hpp
+++ b/src/lexer/lexer.hpp
@@ -15,6 +15,7 @@ struct Lexer {
 
   private:
     [[nodiscard]] vec<Token> tokenize();
+    [[nodiscard]] Token parse_string_literal();
     [[nodiscard]] Token parse_numeric_literal();
     [[nodiscard]] Token parse_identifier();
     [[nodiscard]] str peek_line();

--- a/src/lexer/lexer_utils.cpp
+++ b/src/lexer/lexer_utils.cpp
@@ -44,6 +44,42 @@ int Lexer::get_curr() {
                   .file_name = __FUMO_FILE__.string()};
 }
 
+[[nodiscard]] Token Lexer::parse_string_literal() {
+    std::string str_inner{};
+    get_curr();
+    while (file_stream.peek() != EOF) {
+        if (curr == '"') break;
+
+        if (curr != '\\') {
+            str_inner += curr;
+        } else {
+            if (file_stream.peek() != EOF) {
+            get_curr();
+            } else {
+                lexer_error("Dangling backslash escape character.");
+            }
+            switch (curr) {
+                case 'n': str_inner += '\n'; break;
+                case 't': str_inner += '\t'; break;
+                case '"': str_inner += '"'; break;
+                case '\\': str_inner += '\\'; break;
+                default: lexer_error("Invalid escape code.");
+            }
+        }
+
+        get_curr();
+    }
+    if (curr != '"') {
+        lexer_error("Unmatched quote in string literal.");
+    }
+    return Token { .type = TokenType::string,
+                   .literal = std::move(str_inner),
+                   .line_number = __FUMO_LINE_NUM__,
+                   .line_offset = __FUMO_LINE_OFFSET__,
+                   .file_offset = file_stream.tellg(),
+                   .file_name = __FUMO_FILE__.string()};
+}
+
 [[nodiscard]] Token Lexer::parse_numeric_literal() {
     str value = std::format("{}", char(curr));
     Token token {.type = TokenType::integer};


### PR DESCRIPTION
Hi,

Currently missing tests. I believe
```
t("\"Hello, world!\\"\\n\";",pass),
```
would cover it but I don't really understand how the test files are formatted/how they function so I didn't want to mess with it.

The escape codes could be extracted somewhere else but I couldn't figure an appropriate location. I only re-escape the space characters when printing as they were causing a bit of clutter, especially newlines.